### PR TITLE
Used Surface.fill for higher efficiency

### DIFF
--- a/Conway's Game of Life/game_of_life.py
+++ b/Conway's Game of Life/game_of_life.py
@@ -9,11 +9,14 @@ TICK_SPEED = 30
 
 clock = pygame.time.Clock()
 
-def update(screen, cells, size, with_progress = False):
-    updated_cells = np.zeros((cells.shape[0], cells.shape[1]))
+def update(screen, cells, size, with_progress=False):
+    # Create a blank surface with the same dimensions as the screen
+    updated_surface = pygame.Surface(screen.get_size())
 
-    for row,col in np.ndindex(cells.shape):
-        alive = np.sum(cells[row-1:row+2, col-1:col+2]) - cells[row, col]
+    updated_cells = np.zeros_like(cells)  # Initialize the updated_cells array
+
+    for row, col in np.ndindex(cells.shape):
+        alive = np.sum(cells[row - 1 : row + 2, col - 1 : col + 2]) - cells[row, col]
         color = COLOR_BG if cells[row, col] == 0 else COLOR_ALIVE_NEXT
 
         if cells[row, col] == 1:
@@ -26,12 +29,16 @@ def update(screen, cells, size, with_progress = False):
                     color = COLOR_ALIVE_NEXT
         else:
             if alive == 3:
-                    updated_cells[row, col] = 1
-                    if with_progress:
-                        color = COLOR_ALIVE_NEXT
-        
-        pygame.draw.rect(screen, color, (col*size, row*size, size - 1, size - 1))
-    
+                updated_cells[row, col] = 1
+                if with_progress:
+                    color = COLOR_ALIVE_NEXT
+
+        # Instead of drawing on the screen, draw on the updated_surface
+        pygame.draw.rect(updated_surface, color, (col * size, row * size, size - 1, size - 1))
+
+    # Blit the updated_surface onto the screen
+    screen.blit(updated_surface, (0, 0))
+
     return updated_cells
 
 def main():


### PR DESCRIPTION
In the update function, instead of calling pygame.draw.rect for each cell, which can be a bit slow for larger grids, we can use pygame.Surface.fill to fill the entire screen with the appropriate colors for each cell state. This can be more efficient for rendering large grids.