### PR TITLE
Error resolve for tie game of Tic-Tac-Toe

### DIFF
--- a/Tic-Tac-Toe/TicTacToe.py
+++ b/Tic-Tac-Toe/TicTacToe.py
@@ -53,7 +53,11 @@ def userMove():
 
 def compMove():
     possibleMoves = [x for x,letter in enumerate(board) if letter == " " and x != 0]
+
     move = 0
+    
+    if len(possibleMoves) == 0:
+        return move
 
     for let in ['O','X']:
         for i in possibleMoves:


### PR DESCRIPTION
I have been enjoying your Tic-Tac-Toe Game and found a following error.

Then, I have added lines to return move = 0 to comMove() function.

I am looking forward to merging this change.

Thanks,

---

```
$ python3 TicTacToe.py 
Do you want to play a game (Y/N): Y
-----------------------------------------
Welcome to the tic tac toe game

   |   |   
   |   |  
   |   |   
-----------
   |   |   
   |   |  
   |   |   
-----------
   |   |   
   |   |  
   |   |   

...

Enter a position between 1 to 9: 4
   |   |   
 X | O | X
   |   |   
-----------
   |   |   
 X | X | O
   |   |   
-----------
   |   |   
 O | X | O
   |   |   
Traceback (most recent call last):
  File "TicTacToe.py", line 136, in <module>
    main()
  File "TicTacToe.py", line 119, in main
    insertLetter("O", move)
  File "TicTacToe.py", line 4, in insertLetter
    board[pos] = letter
TypeError: list indices must be integers or slices, not NoneType
```