### PR TITLE
Fixed program crashing when board is full

### DIFF
--- a/Tic-Tac-Toe/TicTacToe.py
+++ b/Tic-Tac-Toe/TicTacToe.py
@@ -109,7 +109,9 @@ def main():
             break
 
 
-        if not(isWinner(board, "X")):
+        if not(isWinner(board, "X")):            
+            if isBoardFull(board):
+                break
             move = compMove()
 
             if move == 0:


### PR DESCRIPTION
added an if statement to break out of while loop if board was full before doing insertLetter(O, move) when move is None due to the board being full, which would cause the program to crash with TypeError: list indices must be integers or slices, not NoneType

now when the board is full, the program declares the outcome of the game and asks if the user would like to play again