### PR TITLE
typo-error

### DIFF
--- a/Tic-Tac-Toe/TicTacToe.py
+++ b/Tic-Tac-Toe/TicTacToe.py
@@ -105,7 +105,7 @@ def main():
             printBoard(board)
 
         else:
-            print("Sorry you loose! ")
+            print("Sorry you lose! ")
             break
 
 


### PR DESCRIPTION
This change revolves #108 by correcting the typo error of 'loose' to 'lose'

Signed-of-by: Aditya Bhushan <bhushanadiit55555@gmail.com>