### PR TITLE
Spelling of lose has been corrected

### DIFF
--- a/Tic-Tac-Toe/TicTacToe.py
+++ b/Tic-Tac-Toe/TicTacToe.py
@@ -105,7 +105,7 @@ def main():
             printBoard(board)
 
         else:
-            print("Sorry you loose! ")
+            print("Sorry you lose! ")
             break
 
 


### PR DESCRIPTION
This PR corrected the spelling of lose.

Fixes #158 